### PR TITLE
Adds bitwise ops AND, OR, and XOR

### DIFF
--- a/src/expression.peg
+++ b/src/expression.peg
@@ -5,12 +5,14 @@ oct = @{ "0o" ~ ("_" | ASCII_OCT_DIGIT)+ }
 bin = @{ "0b" ~ ("_" | ASCII_BIN_DIGIT)+ }
 ans = { "ans" }
 
-operation = _{ add | subtract | multiply | divide | rem | lshift | rshift }
+operation = _{ add | subtract | multiply | divide | rem | and | or | lshift | rshift }
     add      = { "+" }
     subtract = { "-" }
     multiply = { "*" }
     divide   = { "/" }
     rem      = { "%" }
+    and      = { "&" }
+    or       = { "|" }
     lshift   = { "<<" }
     rshift   = { ">>" }
 

--- a/src/expression.peg
+++ b/src/expression.peg
@@ -5,7 +5,7 @@ oct = @{ "0o" ~ ("_" | ASCII_OCT_DIGIT)+ }
 bin = @{ "0b" ~ ("_" | ASCII_BIN_DIGIT)+ }
 ans = { "ans" }
 
-operation = _{ add | subtract | multiply | divide | rem | and | or | lshift | rshift }
+operation = _{ add | subtract | multiply | divide | rem | and | or | xor | lshift | rshift }
     add      = { "+" }
     subtract = { "-" }
     multiply = { "*" }
@@ -13,6 +13,7 @@ operation = _{ add | subtract | multiply | divide | rem | and | or | lshift | rs
     rem      = { "%" }
     and      = { "&" }
     or       = { "|" }
+    xor      = { "^" }
     lshift   = { "<<" }
     rshift   = { ">>" }
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -327,19 +327,34 @@ mod test {
             Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 94),
             _ => panic!("Should have parsed to an expr"),
         };
+        // testing just the bitwise AND
         let expr11_str = "0b0011 & 0b0110";
         match parse_line(expr11_str).unwrap(){
             Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 0b0010),
             _ => panic!("Should have parsed to an expr"),
         }
+        // testing just the bitwise OR
         let expr12_str = "0b0011 | 0b0110";
         match parse_line(expr12_str).unwrap(){
             Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 0b0111),
             _ => panic!("Should have parsed to an expr"),
         }
+        // testing just the bitwise XOR
         let expr13_str = "0b0011 ^ 0b0101";
         match parse_line(expr13_str).unwrap(){
             Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 0b0110),
+            _ => panic!("Should have parsed to an expr"),
+        }
+        // testing all of the bitwise operators together
+        let expr14_str = "((0b0011 ^ 0b0101) & 0b0011) | 0b0111";
+        match parse_line(expr14_str).unwrap(){
+            Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 0b0111),
+            _ => panic!("Should have parsed to an expr"),
+        }
+        // mixing bitwise and "normal" operators
+        let expr15_str = "(((0b0011 ^ 0b0101) * 2) & 0b0101) + 1";
+        match parse_line(expr15_str).unwrap(){
+            Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 5),
             _ => panic!("Should have parsed to an expr"),
         }
     }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -35,6 +35,7 @@ pub enum Op {
     Rem,
     And,
     Or,
+    Xor,
     LShift,
     RShift,
 }
@@ -54,6 +55,7 @@ impl FromStr for Op {
             "%" => Ok(Op::Rem),
             "&" => Ok(Op::And),
             "|" => Ok(Op::Or),
+            "^" => Ok(Op::Xor),
             "<<" => Ok(Op::LShift),
             ">>" => Ok(Op::RShift),
             _ => Err(ParseOpError(format!("{} is not an Op", s))),
@@ -135,7 +137,7 @@ lazy_static! {
         PrecClimber::new(vec![
             Operator::new(lshift, Left) | Operator::new(rshift, Left),
             Operator::new(add, Left) | Operator::new(subtract, Left),
-            Operator::new(multiply, Left) | Operator::new(divide, Left) | Operator::new(rem, Left) | Operator::new(and, Left) | Operator::new(or, Left),
+            Operator::new(multiply, Left) | Operator::new(divide, Left) | Operator::new(rem, Left) | Operator::new(and, Left) | Operator::new(or, Left) | Operator::new(xor, Left),
         ])
     };
 }
@@ -189,6 +191,7 @@ fn parse_expr(expression: Pairs<Rule>) -> Expr {
                 Rule::rem => Op::Rem,
                 Rule::and => Op::And,
                 Rule::or => Op::Or,
+                Rule::xor => Op::Xor,
                 Rule::lshift => Op::LShift,
                 Rule::rshift => Op::RShift,
                 _ => unreachable!(),
@@ -217,6 +220,7 @@ pub mod eval {
                     Op::Mul => Ok(left * right),
                     Op::And => Ok(left & right),
                     Op::Or => Ok(left | right),
+                    Op::Xor => Ok(left ^ right),
                     Op::LShift => Ok(left << right),
                     Op::RShift => Ok(left >> right),
                     Op::Div => {
@@ -328,9 +332,14 @@ mod test {
             Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 0b0010),
             _ => panic!("Should have parsed to an expr"),
         }
-        let expr11_str = "0b0011 | 0b0110";
-        match parse_line(expr11_str).unwrap(){
+        let expr12_str = "0b0011 | 0b0110";
+        match parse_line(expr12_str).unwrap(){
             Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 0b0111),
+            _ => panic!("Should have parsed to an expr"),
+        }
+        let expr13_str = "0b0011 ^ 0b0101";
+        match parse_line(expr13_str).unwrap(){
+            Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 0b0110),
             _ => panic!("Should have parsed to an expr"),
         }
     }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -33,6 +33,8 @@ pub enum Op {
     Mul,
     Div,
     Rem,
+    And,
+    Or,
     LShift,
     RShift,
 }
@@ -50,6 +52,8 @@ impl FromStr for Op {
             "*" => Ok(Op::Mul),
             "/" => Ok(Op::Div),
             "%" => Ok(Op::Rem),
+            "&" => Ok(Op::And),
+            "|" => Ok(Op::Or),
             "<<" => Ok(Op::LShift),
             ">>" => Ok(Op::RShift),
             _ => Err(ParseOpError(format!("{} is not an Op", s))),
@@ -131,7 +135,7 @@ lazy_static! {
         PrecClimber::new(vec![
             Operator::new(lshift, Left) | Operator::new(rshift, Left),
             Operator::new(add, Left) | Operator::new(subtract, Left),
-            Operator::new(multiply, Left) | Operator::new(divide, Left) | Operator::new(rem, Left),
+            Operator::new(multiply, Left) | Operator::new(divide, Left) | Operator::new(rem, Left) | Operator::new(and, Left) | Operator::new(or, Left),
         ])
     };
 }
@@ -183,6 +187,8 @@ fn parse_expr(expression: Pairs<Rule>) -> Expr {
                 Rule::multiply => Op::Mul,
                 Rule::divide => Op::Div,
                 Rule::rem => Op::Rem,
+                Rule::and => Op::And,
+                Rule::or => Op::Or,
                 Rule::lshift => Op::LShift,
                 Rule::rshift => Op::RShift,
                 _ => unreachable!(),
@@ -209,6 +215,8 @@ pub mod eval {
                     Op::Add => Ok(left + right),
                     Op::Sub => Ok(left - right),
                     Op::Mul => Ok(left * right),
+                    Op::And => Ok(left & right),
+                    Op::Or => Ok(left | right),
                     Op::LShift => Ok(left << right),
                     Op::RShift => Ok(left >> right),
                     Op::Div => {
@@ -315,6 +323,16 @@ mod test {
             Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 94),
             _ => panic!("Should have parsed to an expr"),
         };
+        let expr11_str = "0b0011 & 0b0110";
+        match parse_line(expr11_str).unwrap(){
+            Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 0b0010),
+            _ => panic!("Should have parsed to an expr"),
+        }
+        let expr11_str = "0b0011 | 0b0110";
+        match parse_line(expr11_str).unwrap(){
+            Command::Expr(expr) => assert_eq!(eval_expr(&expr, 0).unwrap(), 0b0111),
+            _ => panic!("Should have parsed to an expr"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
This pull request adds support for some bitwise operations:
- AND via "&"
- OR via "|"
- XOR via "^"

What remains unclear to me is how to define operator precedence here. As well, what operations should take precedence over others now that it's possible to mix bitwise operations and "normal" ones. Any feedback or comments you may have would be very appreciated! 