### PR TITLE
 Fixed 0 being displayed empty

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -103,6 +103,11 @@ impl OutputFormat {
         self.radix = radix;
     }
 
+    #[cfg(test)]
+    fn set_punctuate_number(&mut self, punctuate_number: bool) {
+        self.punctuate_number = punctuate_number;
+    }
+
     pub fn fmt(&self, num: i64) -> String {
         let (abs_num, negative) = if num < 0 {
             (-num as u64, true)
@@ -126,6 +131,32 @@ impl OutputFormat {
             format!("-{}{}", prefix, abs_num_str)
         } else {
             format!("{}{}", prefix, abs_num_str)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_0_fmt() {
+        let cases = [
+            (FormatRadix::Hex, "0x0"),
+            (FormatRadix::Octal, "0o0"),
+            (FormatRadix::Binary, "0b0"),
+            (FormatRadix::Decimal, "0"),
+        ];
+
+        for (radix, output) in cases {
+            let mut of = OutputFormat::default().with_format_radix(radix);
+
+            // Regardless of punctuation, output should be the same
+            of.set_punctuate_number(false);
+            assert_eq!(of.fmt(0), output);
+
+            of.set_punctuate_number(true);
+            assert_eq!(of.fmt(0), output);
         }
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -103,11 +103,6 @@ impl OutputFormat {
         self.radix = radix;
     }
 
-    #[cfg(test)]
-    fn set_punctuate_number(&mut self, punctuate_number: bool) {
-        self.punctuate_number = punctuate_number;
-    }
-
     pub fn fmt(&self, num: i64) -> String {
         let (abs_num, negative) = if num < 0 {
             (-num as u64, true)
@@ -152,10 +147,10 @@ mod test {
             let mut of = OutputFormat::default().with_format_radix(radix);
 
             // Regardless of punctuation, output should be the same
-            of.set_punctuate_number(false);
+            of = of.with_punctuate_number(false);
             assert_eq!(of.fmt(0), output);
 
-            of.set_punctuate_number(true);
+            of = of.with_punctuate_number(true);
             assert_eq!(of.fmt(0), output);
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -119,7 +119,7 @@ impl OutputFormat {
             FormatRadix::Decimal => "",
             FormatRadix::Hex => "0x",
             FormatRadix::Octal => "0o",
-            FormatRadix::Binary => "Ob",
+            FormatRadix::Binary => "0b",
         };
 
         if negative {

--- a/src/format.rs
+++ b/src/format.rs
@@ -52,6 +52,9 @@ impl Display for FormatRadix {
 
 fn uint_to_chars_radix(mut num: u64, radix: u32) -> Vec<char> {
     let mut chars = Vec::new();
+    if num == 0 {
+        chars.push('0');
+    }
     while num > 0 {
         let d = (num % radix as u64) as u32;
         chars.push(char::from_digit(d, radix).unwrap());


### PR DESCRIPTION
If an expression has value 0, you will only see the base (e.g. "0x", or "0b" / "").
This fixed it by adding a '0' character, if the number was 0